### PR TITLE
Fix syntax errors from leftover prefixes

### DIFF
--- a/poiskmore_plugin/dialogs/err_editing_dialog.py
+++ b/poiskmore_plugin/dialogs/err_editing_dialog.py
@@ -1,4 +1,4 @@
-pythonfrom PyQt5.QtWidgets import QDialog, QLabel, QLineEdit, QTextEdit, QPushButton, QVBoxLayout, QDateTimeEdit
+from PyQt5.QtWidgets import QDialog, QLabel, QLineEdit, QTextEdit, QPushButton, QVBoxLayout, QDateTimeEdit
 from PyQt5.QtCore import QDateTime
 from PyQt5.QtWidgets import QMessageBox
 

--- a/poiskmore_plugin/dialogs/exercise_dialog.py
+++ b/poiskmore_plugin/dialogs/exercise_dialog.py
@@ -1,4 +1,4 @@
-pythonfrom PyQt5.QtWidgets import QDialog, QVBoxLayout, QLabel, QLineEdit, QTextEdit, QDateEdit, QPushButton
+from PyQt5.QtWidgets import QDialog, QVBoxLayout, QLabel, QLineEdit, QTextEdit, QDateEdit, QPushButton
 from PyQt5.QtCore import QDate
 from PyQt5.QtWidgets import QMessageBox
 

--- a/poiskmore_plugin/dialogs/log_summary_dialog.py
+++ b/poiskmore_plugin/dialogs/log_summary_dialog.py
@@ -1,4 +1,4 @@
-pythonfrom PyQt5.QtWidgets import QDialog, QVBoxLayout, QTextEdit, QPushButton
+from PyQt5.QtWidgets import QDialog, QVBoxLayout, QTextEdit, QPushButton
 import os
 from ..reports.log_summary_generator import generate_log_summary
 

--- a/poiskmore_plugin/dialogs/operator_log_dialog.py
+++ b/poiskmore_plugin/dialogs/operator_log_dialog.py
@@ -1,4 +1,4 @@
-pythonfrom PyQt5.QtWidgets import QDialog, QVBoxLayout, QTextEdit, QPushButton
+from PyQt5.QtWidgets import QDialog, QVBoxLayout, QTextEdit, QPushButton
 import os
 
 class OperatorLogDialog(QDialog):

--- a/poiskmore_plugin/dialogs/region_dialog.py
+++ b/poiskmore_plugin/dialogs/region_dialog.py
@@ -1,4 +1,4 @@
-pythonfrom PyQt5.QtWidgets import QDialog, QVBoxLayout, QLabel, QPushButton, QDateTimeEdit, QLineEdit
+from PyQt5.QtWidgets import QDialog, QVBoxLayout, QLabel, QPushButton, QDateTimeEdit, QLineEdit
 from PyQt5.QtCore import QDateTime
 from PyQt5.QtGui import QDoubleValidator
 from ..controllers.region_create import RegionCreateController

--- a/poiskmore_plugin/dialogs/search_scheme_dialog.py
+++ b/poiskmore_plugin/dialogs/search_scheme_dialog.py
@@ -1,4 +1,4 @@
-pythonfrom PyQt5.QtWidgets import QDialog, QVBoxLayout, QLabel, QLineEdit, QPushButton, QSpinBox
+from PyQt5.QtWidgets import QDialog, QVBoxLayout, QLabel, QLineEdit, QPushButton, QSpinBox
 from PyQt5.QtGui import QDoubleValidator
 from PyQt5.QtWidgets import QMessageBox
 

--- a/poiskmore_plugin/dialogs/sru_routing_dialog.py
+++ b/poiskmore_plugin/dialogs/sru_routing_dialog.py
@@ -1,4 +1,4 @@
-pythonfrom PyQt5.QtWidgets import QDialog, QVBoxLayout, QLabel, QLineEdit, QPushButton
+from PyQt5.QtWidgets import QDialog, QVBoxLayout, QLabel, QLineEdit, QPushButton
 from qgis.core import QgsPointXY
 from PyQt5.QtWidgets import QMessageBox
 from PyQt5.QtGui import QRegExpValidator

--- a/poiskmore_plugin/tests/test_assign_sru.py
+++ b/poiskmore_plugin/tests/test_assign_sru.py
@@ -1,4 +1,4 @@
-pythonimport pytest
+import pytest
 from ..controllers.assign_sru_by_distance import calculate_distance
 from qgis.core import QgsPointXY
 

--- a/poiskmore_plugin/tests/test_heatmap_render.py
+++ b/poiskmore_plugin/tests/test_heatmap_render.py
@@ -1,4 +1,4 @@
-pythonimport pytest
+import pytest
 from qgis.core import QgsHeatmapRenderer, QgsColorRampShader
 
 @pytest.fixture

--- a/poiskmore_plugin/tests/test_log_storage.py
+++ b/poiskmore_plugin/tests/test_log_storage.py
@@ -1,4 +1,4 @@
-pythonimport pytest
+import pytest
 import os
 from ..utils.operator_log import log_action
 

--- a/poiskmore_plugin/tests/test_runner.py
+++ b/poiskmore_plugin/tests/test_runner.py
@@ -1,4 +1,4 @@
-pythonimport subprocess
+import subprocess
 
 def run_pytest_in_qgis_env():
     try:

--- a/poiskmore_plugin/utils/buffer_zone.py
+++ b/poiskmore_plugin/utils/buffer_zone.py
@@ -1,4 +1,4 @@
-pythonfrom qgis.core import QgsGeometry
+from qgis.core import QgsGeometry
 
 def create_buffer(geom: QgsGeometry, distance=0.05, segments=12):
     if not geom:

--- a/poiskmore_plugin/utils/icon_loader.py
+++ b/poiskmore_plugin/utils/icon_loader.py
@@ -1,4 +1,4 @@
-pythonfrom PyQt5.QtGui import QIcon
+from PyQt5.QtGui import QIcon
 import os
 
 def load_icon(name):

--- a/poiskmore_plugin/utils/layout_template.py
+++ b/poiskmore_plugin/utils/layout_template.py
@@ -1,4 +1,4 @@
-pythonfrom qgis.core import QgsProject, QgsLayoutItemLabel, QgsLayoutPoint
+from qgis.core import QgsProject, QgsLayoutItemLabel, QgsLayoutPoint
 from qgis.PyQt.QtGui import QColor
 
 def create_layout(canvas, title="Поиск-Море"):

--- a/poiskmore_plugin/utils/map_snapshot.py
+++ b/poiskmore_plugin/utils/map_snapshot.py
@@ -1,4 +1,4 @@
-pythonfrom qgis.gui import QgsMapCanvas
+from qgis.gui import QgsMapCanvas
 from PyQt5.QtGui import QImage, QPainter
 
 def save_canvas_as_image(canvas: QgsMapCanvas, path="snapshot.png"):

--- a/poiskmore_plugin/utils/point_in_polygon.py
+++ b/poiskmore_plugin/utils/point_in_polygon.py
@@ -1,4 +1,4 @@
-pythonfrom qgis.core import QgsGeometry, QgsPointXY
+from qgis.core import QgsGeometry, QgsPointXY
 
 def is_point_inside_zone(point: QgsPointXY, zone_geom: QgsGeometry):
     if not point or not zone_geom:

--- a/poiskmore_plugin/utils/reset_plugin_state.py
+++ b/poiskmore_plugin/utils/reset_plugin_state.py
@@ -1,4 +1,4 @@
-pythonimport os
+import os
 
 def reset_plugin_state(files=None):
     if files is None:


### PR DESCRIPTION
## Summary
- remove stray `python` prefix text from dialog, util and test modules

## Testing
- `pytest -q` *(fails: attempted relative import with no known parent package)*

------
https://chatgpt.com/codex/tasks/task_e_6884b91fc910833084f36868f3cd1c2e