### PR TITLE
Fix missing SITREP module

### DIFF
--- a/poiskmore_plugin/dialogs/sitrep_dialog.py
+++ b/poiskmore_plugin/dialogs/sitrep_dialog.py
@@ -1,0 +1,6 @@
+from .dialog_sitrep import SitrepForm
+
+class SitrepDialog(SitrepForm):
+    def __init__(self, iface=None):
+        super().__init__(parent=iface)
+


### PR DESCRIPTION
## Summary
- add `poiskmore_plugin/dialogs/sitrep_dialog.py` to match expected import path

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'qgis', NameError: name 'python' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_688bfe3c7b588330873676701312ae5d