### PR TITLE
Fix missing sitrep dialog

### DIFF
--- a/poiskmore_plugin/poiskmore.py
+++ b/poiskmore_plugin/poiskmore.py
@@ -1,7 +1,7 @@
 from qgis.PyQt.QtWidgets import QAction, QMenu
 from qgis.utils import iface
 
-from .dialogs.sitrep_dialog import SitrepDialog
+from .dialogs.dialog_sitrep import SitrepForm
 from .dialogs.region_dialog import RegionDialog
 from .dialogs.exercise_dialog import ExerciseDialog
 from .dialogs.err_editing_dialog import ErrEditingDialog
@@ -44,7 +44,7 @@ class PoiskMorePlugin:
             self.iface.removePluginMenu("Поиск-Море", action)
 
     def run_sitrep(self):
-        SitrepDialog(self.iface).exec_()
+        SitrepForm(self.iface.mainWindow()).exec_()
 
     def run_region(self):
         RegionDialog(self.iface, self.iface.mapCanvas()).exec_()


### PR DESCRIPTION
## Summary
- correct import for SITREP dialog in plugin

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'qgis')*

------
https://chatgpt.com/codex/tasks/task_e_688bfe3c7b588330873676701312ae5d