### PR TITLE
Fix plugin import for SITREP dialog

### DIFF
--- a/poiskmore_plugin/dialogs/sitrep_dialog.py
+++ b/poiskmore_plugin/dialogs/sitrep_dialog.py
@@ -1,0 +1,1 @@
+from .dialog_sitrep import SitrepForm as SitrepDialog


### PR DESCRIPTION
## Summary
- add a thin wrapper so `poiskmore_plugin.dialogs.sitrep_dialog` resolves

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'qgis')*

------
https://chatgpt.com/codex/tasks/task_e_688bfe3c7b588330873676701312ae5d