### PR TITLE
Fix QGIS UI file structure

### DIFF
--- a/poiskmore_plugin/forms/AdvancedSearchAreaForm.ui
+++ b/poiskmore_plugin/forms/AdvancedSearchAreaForm.ui
@@ -6,7 +6,8 @@
    <string>Параметры района поиска</string>
   </property>
   <layout class="QVBoxLayout" name="mainLayout">
-   <widget class="QTabWidget" name="tabWidget">
+   <item>
+    <widget class="QTabWidget" name="tabWidget">
     <!-- Вкладка «Район 1» -->
     <widget class="QWidget" name="tabArea1">
      <attribute name="title">
@@ -76,7 +77,8 @@
       <string>Итоги</string>
      </attribute>
      <layout class="QVBoxLayout" name="vboxSummary">
-      <widget class="QGroupBox" name="boxErrors">
+      <item>
+       <widget class="QGroupBox" name="boxErrors">
        <property name="title"><string>Расчёт продолжительности поиска</string></property>
        <layout class="QFormLayout" name="formErrors">
         <item row="0" column="0">
@@ -139,9 +141,11 @@
         </item>
        </layout>
       </widget>
+      </item>
      </layout>
     </widget>
    </widget>
+   </item>
   </layout>
  </widget>
  <resources/>

--- a/poiskmore_plugin/forms/CurrentSummaryForm.ui
+++ b/poiskmore_plugin/forms/CurrentSummaryForm.ui
@@ -5,13 +5,16 @@
   <property name="windowTitle">
    <string>Расчёт суммарного течения (TWC)</string>
   </property>
-  <layout class="QVBoxLayout" name="vboxMain">
-    <widget class="QLabel" name="labelPeriod">
+   <layout class="QVBoxLayout" name="vboxMain">
+     <item>
+      <widget class="QLabel" name="labelPeriod">
       <property name="text">
        <string>Рассматриваемый период: 22.07.2025 21:02 – 23.07.2025 10:02</string>
       </property>
-    </widget>
-    <widget class="QTableWidget" name="tableVectors">
+     </widget>
+     </item>
+     <item>
+      <widget class="QTableWidget" name="tableVectors">
       <property name="columnCount"><number>5</number></property>
       <column>
         <property name="text"><string>Тип</string></property>
@@ -28,8 +31,10 @@
       <column>
         <property name="text"><string>Актуально по</string></property>
       </column>
-    </widget>
-    <widget class="QGroupBox" name="boxSummary">
+     </widget>
+     </item>
+     <item>
+      <widget class="QGroupBox" name="boxSummary">
       <property name="title"><string>Расчёт суммарного течения</string></property>
       <layout class="QFormLayout" name="formSummary">
         <item row="0" column="0">
@@ -95,8 +100,9 @@
           </layout>
         </item>
       </layout>
-    </widget>
-  </layout>
+      </widget>
+     </item>
+    </layout>
  </widget>
  <resources/>
  <connections/>

--- a/poiskmore_plugin/forms/CurrentSummaryForm0.ui
+++ b/poiskmore_plugin/forms/CurrentSummaryForm0.ui
@@ -5,19 +5,24 @@
   <property name="windowTitle">
    <string>Расчёт суммарного течения (TWC)</string>
   </property>
-  <layout class="QVBoxLayout" name="vboxMain">
-   <widget class="QLabel" name="labelPeriod">
+   <layout class="QVBoxLayout" name="vboxMain">
+    <item>
+     <widget class="QLabel" name="labelPeriod">
     <property name="text"><string>Период: …</string></property>
-   </widget>
-   <widget class="QTableWidget" name="tableVectors">
+    </widget>
+    </item>
+    <item>
+     <widget class="QTableWidget" name="tableVectors">
     <property name="columnCount"><number>5</number></property>
     <column><property name="text"><string>Тип</string></property></column>
     <column><property name="text"><string>Скорость, узлы</string></property></column>
     <column><property name="text"><string>Направление</string></property></column>
     <column><property name="text"><string>Актуально с</string></property></column>
     <column><property name="text"><string>Актуально по</string></property></column>
-   </widget>
-   <widget class="QGroupBox" name="boxSummary">
+    </widget>
+    </item>
+    <item>
+     <widget class="QGroupBox" name="boxSummary">
     <property name="title"><string>Расчёт суммарного течения</string></property>
     <layout class="QFormLayout" name="formSummary">
      <item row="0" column="0">
@@ -84,6 +89,7 @@
      </item>
     </layout>
    </widget>
+   </item>
   </layout>
  </widget>
  <resources/>

--- a/poiskmore_plugin/forms/IncomingAlertForm.ui
+++ b/poiskmore_plugin/forms/IncomingAlertForm.ui
@@ -93,7 +93,19 @@
       <layout class="QFormLayout" name="layoutState4">
        <!-- Поля для состояния №4: Тип объекта, Метод симуляции, Расстояние DR, Время от определения -->
        <item row="0" column="0"><widget class="QLabel" name="labelObjectType"><property name="text"><string>Тип объекта:</string></property></widget></item>
-       <item row="0" column="1"><widget class="QComboBox" name="comboObjectType"><item><string>Аварийный сигнал (ha 4-6 человек)</string></item><item><string>6-местный спас. плот</string></item><item><string>GNSS</string></item></widget></item>
+       <item row="0" column="1">
+        <widget class="QComboBox" name="comboObjectType">
+         <item>
+          <property name="text"><string>Аварийный сигнал (ha 4-6 человек)</string></property>
+         </item>
+         <item>
+          <property name="text"><string>6-местный спас. плот</string></property>
+         </item>
+         <item>
+          <property name="text"><string>GNSS</string></property>
+         </item>
+        </widget>
+       </item>
        <item row="1" column="0"><widget class="QCheckBox" name="checkSimulate"><property name="text"><string>Использовать метод симуляции пути</string></property></widget></item>
        <item row="2" column="0"><widget class="QLabel" name="labelDR"><property name="text"><string>Расстояние DR:</string></property></widget></item>
        <item row="2" column="1"><widget class="QDoubleSpinBox" name="spinDR"/></item>

--- a/poiskmore_plugin/forms/SitrepSendForm.ui
+++ b/poiskmore_plugin/forms/SitrepSendForm.ui
@@ -10,7 +10,16 @@
       <attribute name="title"><string>Заголовок</string></attribute>
       <layout class="QFormLayout" name="layoutHeader">
        <item row="0" column="0"><widget class="QLabel" name="labelCategory"><property name="text"><string>Категория сообщения:</string></property></widget></item>
-       <item row="0" column="1"><widget class="QComboBox" name="comboCategory"><item><string>Бедствие</string></item><item><string>Тренировка</string></item></widget></item>
+       <item row="0" column="1">
+        <widget class="QComboBox" name="comboCategory">
+         <item>
+          <property name="text"><string>Бедствие</string></property>
+         </item>
+         <item>
+          <property name="text"><string>Тренировка</string></property>
+         </item>
+        </widget>
+       </item>
        <item row="1" column="0"><widget class="QLabel" name="labelDateTime"><property name="text"><string>Дата / Время (UTC) *:</string></property></widget></item>
        <item row="1" column="1"><widget class="QDateTimeEdit" name="dateTimeUtc"><property name="displayFormat"><string>dd MMMM yyyy г. HH:mm</string></property><property name="calendarPopup"><bool>true</bool></property></widget></item>
        <item row="2" column="0"><widget class="QLabel" name="labelFrom"><property name="text"><string>От кого:</string></property></widget></item>
@@ -33,9 +42,27 @@
        <item row="1" column="1" colspan="3"><widget class="QLineEdit" name="editLocation"/></item>
        <item row="2" column="0"><widget class="QLabel" name="labelCoords"><property name="text"><string>Координаты *:</string></property></widget></item>
        <item row="2" column="1"><widget class="QDoubleSpinBox" name="spinLat"><property name="suffix"><string> °</string></property><property name="decimals"><number>6</number></property></widget></item>
-       <item row="2" column="2"><widget class="QComboBox" name="comboLatDir"><item><string>С.Ш.</string></item><item><string>Ю.Ш.</string></item></widget></item>
+         <item row="2" column="2">
+          <widget class="QComboBox" name="comboLatDir">
+           <item>
+            <property name="text"><string>С.Ш.</string></property>
+           </item>
+           <item>
+            <property name="text"><string>Ю.Ш.</string></property>
+           </item>
+          </widget>
+         </item>
        <item row="2" column="3"><widget class="QDoubleSpinBox" name="spinLon"><property name="suffix"><string> °</string></property><property name="decimals"><number>6</number></property></widget></item>
-       <item row="2" column="4"><widget class="QComboBox" name="comboLonDir"><item><string>В.Д.</string></item><item><string>З.Д.</string></item></widget></item>
+         <item row="2" column="4">
+          <widget class="QComboBox" name="comboLonDir">
+           <item>
+            <property name="text"><string>В.Д.</string></property>
+           </item>
+           <item>
+            <property name="text"><string>З.Д.</string></property>
+           </item>
+          </widget>
+         </item>
        <item row="3" column="0"><widget class="QLabel" name="labelSituation"><property name="text"><string>Ситуация:</string></property></widget></item>
        <item row="3" column="1" colspan="4"><widget class="QTextEdit" name="textSituation"/></item>
        <item row="4" column="0"><widget class="QLabel" name="labelSourceInfo"><property name="text"><string>Источник информации:</string></property></widget></item>

--- a/poiskmore_plugin/forms/WindSummaryForm.ui
+++ b/poiskmore_plugin/forms/WindSummaryForm.ui
@@ -5,11 +5,14 @@
   <property name="windowTitle">
    <string>Расчёт среднего ветра (ASW)</string>
   </property>
-  <layout class="QVBoxLayout" name="vboxMain">
-    <widget class="QLabel" name="labelPeriod">
+   <layout class="QVBoxLayout" name="vboxMain">
+     <item>
+      <widget class="QLabel" name="labelPeriod">
       <property name="text"><string>Период дрейфа: 22.07.2025 21:02 – 23.07.2025 10:02</string></property>
-    </widget>
-    <widget class="QTableWidget" name="tableVectors">
+     </widget>
+     </item>
+     <item>
+      <widget class="QTableWidget" name="tableVectors">
       <property name="columnCount"><number>4</number></property>
       <column>
         <property name="text"><string>Скорость, узлы</string></property>
@@ -23,8 +26,10 @@
       <column>
         <property name="text"><string>Актуально по</string></property>
       </column>
-    </widget>
-    <widget class="QGroupBox" name="boxSummary">
+     </widget>
+     </item>
+     <item>
+      <widget class="QGroupBox" name="boxSummary">
       <property name="title"><string>Средний приземный ветер</string></property>
       <layout class="QFormLayout" name="formSummary">
         <item row="0" column="0">
@@ -71,9 +76,10 @@
             </item>
           </layout>
         </item>
-      </layout>
-    </widget>
-  </layout>
+        </layout>
+      </widget>
+      </item>
+    </layout>
  </widget>
  <resources/>
  <connections/>


### PR DESCRIPTION
## Summary
- wrap widget elements in `item` containers for valid layouts
- correct combo box item syntax
- ensure generated UI files are valid XML

## Testing
- `python - <<'PY' ...` (XML parse check)
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'qgis')*

------
https://chatgpt.com/codex/tasks/task_e_688c82d5230883309b4e618c0f173f05