### PR TITLE
Fix region dialog indentation to load plugin

### DIFF
--- a/poiskmore_plugin/dialogs/region_dialog.py
+++ b/poiskmore_plugin/dialogs/region_dialog.py
@@ -1,9 +1,20 @@
+"""Диалог выбора района поиска."""
+
+import os
 from PyQt5.QtWidgets import QDialog
 from PyQt5 import uic
-import os
 from qgis.core import QgsMapCanvas
+
+
 class RegionDialog(QDialog):
-def init(self, iface, canvas: QgsMapCanvas):
-super().init()
-uic.loadUi(os.path.join(os.path.dirname(file), '../forms/RegionForm.ui'), self)  # Assuming form
-self.canvas = canvas
+    """Простой диалог выбора района поиска."""
+
+    def __init__(self, iface=None, canvas: QgsMapCanvas | None = None, parent=None):
+        super().__init__(parent)
+        ui_path = os.path.join(os.path.dirname(__file__), "../forms/RegionForm.ui")
+        if os.path.exists(ui_path):
+            uic.loadUi(ui_path, self)
+
+        self.iface = iface
+        self.canvas = canvas
+


### PR DESCRIPTION
## Summary
- rewrite RegionDialog with proper `__init__` and UI loading

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'qgis')*


------
https://chatgpt.com/codex/tasks/task_e_688e9a6d0328833092f3abbcfb72c894