### PR TITLE
Fix metadata formatting for QGIS plugin

### DIFF
--- a/metadata.txt
+++ b/metadata.txt
@@ -1,11 +1,4 @@
-plaintext
-
-Свернуть
-
-Перенос
-
-Копировать
-[GENERAL]
+[general]
 name=Поиск-Море
 qgisMinimumVersion=3.0
 description=Плагин для поисково-спасательных операций на море по IAMSAR
@@ -18,6 +11,6 @@ about=Расчёты дрейфа, зон поиска, отчёты SITREP, и�
 hasProcessingProvider=no
 homepage=https://yourwebsite.com
 tracker=https://github.com/yourrepo/issues
-icon=:/images/icon.png
+icon=resources/icon.png
 category=Plugins
 tags=search, rescue, marine, IAMSAR

--- a/poiskmore_plugin/metadata.txt
+++ b/poiskmore_plugin/metadata.txt
@@ -1,1 +1,16 @@
-plaintext [GENERAL] name=Поиск-Море qgisMinimumVersion=3.0 description=Плагин для поисково-спасательных операций на море по IAMSAR version=1.0 experimental=True author=Ваше имя email=your@email.com repository=https://github.com/yourrepo/poisk-more-qgis about=Расчёты дрейфа, зон поиска, отчёты SITREP, интеграция с БД/MQ/email. hasProcessingProvider=no homepage=https://yourwebsite.com tracker=https://github.com/yourrepo/issues icon=resources/icon.png category=Plugins tags=search, rescue, marine, IAMSAR
+[general]
+name=Поиск-Море
+qgisMinimumVersion=3.0
+description=Плагин для поисково-спасательных операций на море по IAMSAR
+version=1.0
+experimental=True
+author=Ваше имя
+email=your@email.com
+repository=https://github.com/yourrepo/poisk-more-qgis
+about=Расчёты дрейфа, зон поиска, отчёты SITREP, интеграция с БД/MQ/email.
+hasProcessingProvider=no
+homepage=https://yourwebsite.com
+tracker=https://github.com/yourrepo/issues
+icon=resources/icon.png
+category=Plugins
+tags=search, rescue, marine, IAMSAR


### PR DESCRIPTION
## Summary
- replace corrupted metadata with properly formatted key-value pairs
- ensure both project and plugin metadata define name, version, and icon

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'qgis')*
- `pip install qgis -q` *(fails: ERROR: Could not find a version that satisfies the requirement qgis)*

------
https://chatgpt.com/codex/tasks/task_e_688ea27266508330bbfebe65ecc9d9d7