### PR TITLE
fix: correct metadata section

### DIFF
--- a/poiskmore_plugin/metadata.txt
+++ b/poiskmore_plugin/metadata.txt
@@ -1,4 +1,4 @@
-[GENERAL]
+[general]
 name=Поиск-Море
 qgisMinimumVersion=3.0
 description=Плагин для поисково-спасательных операций на море по IAMSAR


### PR DESCRIPTION
## Summary
- fix plugin metadata section name to lowercase 'general' to allow QGIS installer to recognize it

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'qgis')*

------
https://chatgpt.com/codex/tasks/task_e_688ea722d314833098a7e004bf28cc96