### PR TITLE
Fix probability map resolution zero handling

### DIFF
--- a/poiskmore_plugin/alg/alg_probabilities.py
+++ b/poiskmore_plugin/alg/alg_probabilities.py
@@ -17,6 +17,10 @@ def compute_probability_map(
     time_hours,
 ):
     """Возвращает матрицу вероятностей вокруг LKP."""
+    if radius <= 0:
+        raise ValueError("Radius must be greater than 0")
+    if resolution <= 0:
+        raise ValueError("Resolution must be greater than 0")
 
     drift_x, drift_y = calculate_drift(
         0, 0, wind_speed, wind_dir, current_speed, current_dir, time_hours

--- a/poiskmore_plugin/forms/ProbabilityForm.ui
+++ b/poiskmore_plugin/forms/ProbabilityForm.ui
@@ -11,8 +11,17 @@
    <item row="1" column="1"><widget class="QDoubleSpinBox" name="spinLkpLon"></widget></item>
    <item row="2" column="0"><widget class="QLabel"><property name="text"><string>Радиус (км):</string></property></widget></item>
    <item row="2" column="1"><widget class="QDoubleSpinBox" name="spinRadius"></widget></item>
-   <item row="3" column="0"><widget class="QLabel"><property name="text"><string>Разрешение (км):</string></property></widget></item>
-   <item row="3" column="1"><widget class="QDoubleSpinBox" name="spinResolution"></widget></item>
+    <item row="3" column="0"><widget class="QLabel"><property name="text"><string>Разрешение (км):</string></property></widget></item>
+    <item row="3" column="1">
+     <widget class="QDoubleSpinBox" name="spinResolution">
+      <property name="minimum">
+       <double>0.1</double>
+      </property>
+      <property name="value">
+       <double>5.0</double>
+      </property>
+     </widget>
+    </item>
    <item row="4" column="0"><widget class="QLabel"><property name="text"><string>Скорость ветра (м/с):</string></property></widget></item>
    <item row="4" column="1"><widget class="QDoubleSpinBox" name="spinWindSpeed"></widget></item>
    <item row="5" column="0"><widget class="QLabel"><property name="text"><string>Направление ветра (°):</string></property></widget></item>

--- a/poiskmore_plugin/tests/conftest.py
+++ b/poiskmore_plugin/tests/conftest.py
@@ -1,10 +1,12 @@
 import os
 import sys
-from qgis.core import QgsApplication
 
-# Initialize QGIS for tests
-qgs = QgsApplication([], False)
-qgs.initQgis()
+try:
+    from qgis.core import QgsApplication
 
-# Add plugin root to path
+    qgs = QgsApplication([], False)
+    qgs.initQgis()
+except ImportError:
+    qgs = None
+
 sys.path.append(os.path.join(os.path.dirname(__file__), ".."))

--- a/poiskmore_plugin/tests/test_probability_map.py
+++ b/poiskmore_plugin/tests/test_probability_map.py
@@ -1,2 +1,14 @@
-python import pytest from alg.alg_probabilities import compute_probability_map
-def test_probability_map_shape(): matrix = compute_probability_map((60, 30), 50, 5, 10, 45, 2, 90, 3) assert matrix.shape == (20, 20)
+import pytest
+
+from alg.alg_probabilities import compute_probability_map
+
+
+def test_probability_map_shape():
+    matrix = compute_probability_map((60, 30), 50, 5, 10, 45, 2, 90, 3)
+    assert matrix.shape == (20, 20)
+
+
+def test_zero_resolution_error():
+    with pytest.raises(ValueError):
+        compute_probability_map((60, 30), 50, 0, 10, 45, 2, 90, 3)
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,12 @@
 import os
 import sys
-from qgis.core import QgsApplication
 
-# Initialize QGIS for tests
-qgs = QgsApplication([], False)
-qgs.initQgis()
+try:
+    from qgis.core import QgsApplication
 
-# Add plugin root to path
+    qgs = QgsApplication([], False)
+    qgs.initQgis()
+except ImportError:
+    qgs = None
+
 sys.path.append(os.path.join(os.path.dirname(__file__), ".."))

--- a/tests/test_probability_map.py
+++ b/tests/test_probability_map.py
@@ -1,2 +1,14 @@
-python import pytest from alg.alg_probabilities import compute_probability_map
-def test_probability_map_shape(): matrix = compute_probability_map((60, 30), 50, 5, 10, 45, 2, 90, 3) assert matrix.shape == (20, 20)
+import pytest
+
+from poiskmore_plugin.alg.alg_probabilities import compute_probability_map
+
+
+def test_probability_map_shape():
+    matrix = compute_probability_map((60, 30), 50, 5, 10, 45, 2, 90, 3)
+    assert matrix.shape == (20, 20)
+
+
+def test_zero_resolution_error():
+    with pytest.raises(ValueError):
+        compute_probability_map((60, 30), 50, 0, 10, 45, 2, 90, 3)
+


### PR DESCRIPTION
## Summary
- validate radius and resolution in `compute_probability_map`
- set positive default for resolution in probability dialog
- add tests for probability map shape and zero resolution error

## Testing
- `pytest tests/test_probability_map.py poiskmore_plugin/tests/test_probability_map.py -q` *(fails: No module named 'numpy')*
- `pip install numpy` *(fails: Could not find a version that satisfies the requirement numpy)*

------
https://chatgpt.com/codex/tasks/task_e_688f91c21844833081eeed3431445658