### PR TITLE
Use relative imports for internal modules

### DIFF
--- a/poiskmore_plugin/mainPlugin.py
+++ b/poiskmore_plugin/mainPlugin.py
@@ -6,21 +6,21 @@ from qgis.PyQt.QtCore import QUrl
 from qgis.core import Qgis, QgsApplication, QgsProject, QgsFeature, QgsGeometry, QgsPointXY, QgsVectorLayer
 from qgis.gui import QgsMapToolEmitPoint
 
-from dialogs.dialog_registration import RegistrationDialog
-from dialogs.dialog_weather import WeatherDialog
-from dialogs.dialog_searcharea import SearchAreaDialog
-from dialogs.dialog_sitrep import SitrepDialog
-from dialogs.dialog_asw import AswDialog
-from dialogs.dialog_twc import TwcDialog
-from dialogs.dialog_operation_edit import OperationEditDialog
-from dialogs.dialog_incident_object import IncidentObjectDialog
-from dialogs.dialog_search_params import SearchParamsDialog
-from dialogs.dialog_search_object import SearchObjectDialog
+from .dialogs.dialog_registration import RegistrationDialog
+from .dialogs.dialog_weather import WeatherDialog
+from .dialogs.dialog_searcharea import SearchAreaDialog
+from .dialogs.dialog_sitrep import SitrepDialog
+from .dialogs.dialog_asw import AswDialog
+from .dialogs.dialog_twc import TwcDialog
+from .dialogs.dialog_operation_edit import OperationEditDialog
+from .dialogs.dialog_incident_object import IncidentObjectDialog
+from .dialogs.dialog_search_params import SearchParamsDialog
+from .dialogs.dialog_search_object import SearchObjectDialog
 
-from alg.alg_datum import calculate_datum_points, add_datum_layer
-from alg.alg_zone import create_search_area, add_search_layer
-from alg.alg_distant_points import distant_points_calculation
-from alg.alg_manual_area import manual_area, ManualAreaTool
+from .alg.alg_datum import calculate_datum_points, add_datum_layer
+from .alg.alg_zone import create_search_area, add_search_layer
+from .alg.alg_distant_points import distant_points_calculation
+from .alg.alg_manual_area import manual_area, ManualAreaTool
 
 class PoiskMorePlugin:
     def __init__(self, iface):

--- a/poiskmore_plugin/tests/test_algorithms.py
+++ b/poiskmore_plugin/tests/test_algorithms.py
@@ -1,2 +1,10 @@
-python import pytest from alg.alg_drift import calculate_drift
-def test_drift_calculation(): result = calculate_drift(60, 30, 10, 45, 2, 90, 3) assert result[0] > 60 # Проверка на положительный сдвиг
+import pytest
+from ..alg.alg_drift import calculate_drift
+from qgis.core import QgsPointXY
+
+
+def test_drift_calculation():
+    start = QgsPointXY(0, 0)
+    result = calculate_drift(start, 30, 10, 45, 2, 3)
+    # Проверка на положительный сдвиг по оси X
+    assert result.x() > start.x()

--- a/poiskmore_plugin/utils/duty_tablet_manager.py
+++ b/poiskmore_plugin/utils/duty_tablet_manager.py
@@ -1,5 +1,7 @@
-from dialogs.dialog_duty_tablet import DialogDutyOfficerTablet
+from ..dialogs.dialog_duty_tablet import DialogDutyOfficerTablet
+
+
 class DutyTabletManager:
-def open_tablet(self, case_id):
-dialog = DialogDutyOfficerTablet(None)
-dialog.exec_()
+    def open_tablet(self, case_id):
+        dialog = DialogDutyOfficerTablet(None)
+        dialog.exec_()


### PR DESCRIPTION
## Summary
- fix main plugin to import dialogs and algorithms relatively
- adjust duty tablet manager to reference dialog package correctly
- tidy algorithm test for drift calculation

## Testing
- `pytest` *(fails: No module named 'qgis'; multiple syntax errors in tests)*

------
https://chatgpt.com/codex/tasks/task_e_689a52df76f0833093ed081257a9cff3