### PR TITLE
Restore top-level menu and fix dialog imports

### DIFF
--- a/poiskmore_plugin/dialogs/dialog_registration.py
+++ b/poiskmore_plugin/dialogs/dialog_registration.py
@@ -1,4 +1,17 @@
-from PyQt5.QtWidgets import QDialog, QLineEdit, QPushButton, QVBoxLayout, QMessageBox, QLabel, QTabWidget, QTextEdit, QComboBox, QDoubleSpinBox, QSpinBox
+from PyQt5.QtWidgets import (
+    QDialog,
+    QLineEdit,
+    QPushButton,
+    QVBoxLayout,
+    QMessageBox,
+    QLabel,
+    QTabWidget,
+    QTextEdit,
+    QComboBox,
+    QDoubleSpinBox,
+    QSpinBox,
+    QWidget,
+)
 from PyQt5.QtCore import QDateTime
 from PyQt5.QtWidgets import QDateTimeEdit
 

--- a/poiskmore_plugin/dialogs/region_dialog.py
+++ b/poiskmore_plugin/dialogs/region_dialog.py
@@ -1,5 +1,5 @@
 """Диалог выбора района поиска с отображением OpenSeaMap."""
-from PyQt5.QtWidgets import QDialog, QVBoxLayout, QMessageBox
+from PyQt5.QtWidgets import QDialog, QVBoxLayout, QMessageBox, QWidget, QPushButton
 from PyQt5 import uic
 import os
 from qgis.core import QgsProject, QgsRasterLayer

--- a/poiskmore_plugin/mainPlugin.py
+++ b/poiskmore_plugin/mainPlugin.py
@@ -28,6 +28,7 @@ class PoiskMorePlugin:
     def __init__(self, iface):
         self.iface = iface
         self.menu = None
+        self._menu_bar = None
         self.actions = {}
         self.plugin_dir = os.path.dirname(__file__)
         self.current_operation = None
@@ -36,7 +37,8 @@ class PoiskMorePlugin:
 
     def initGui(self):
         self.menu = QMenu("Поиск-Море", self.iface.mainWindow())
-        self.iface.addPluginToMenu("Поиск-Море", self.menu.menuAction())
+        self._menu_bar = self.iface.mainWindow().menuBar()
+        self._menu_bar.addMenu(self.menu)
 
         search_menu = QMenu("Поиск", self.menu)
         self.menu.addMenu(search_menu)
@@ -310,6 +312,10 @@ class PoiskMorePlugin:
         QDesktopServices.openUrl(QUrl.fromLocalFile(os.path.join(self.plugin_dir, 'docs/manual.pdf')))
 
     def unload(self):
-        self.iface.removePluginMenu("Поиск-Море", self.menu.menuAction())
-        self.menu.deleteLater()
+        if self._menu_bar and self.menu:
+            self._menu_bar.removeAction(self.menu.menuAction())
+        if self.menu:
+            self.menu.deleteLater()
+        self.menu = None
+        self._menu_bar = None
         self.actions.clear()


### PR DESCRIPTION
## Summary
- Return Поиск-Море to QGIS main menu bar
- Fix missing QWidget imports in registration and region dialogs

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'qgis')*

------
https://chatgpt.com/codex/tasks/task_e_689b075ddf0883308029fabc06e96957