### PR TITLE
Fix missing QWidget import in registration dialog

### DIFF
--- a/poiskmore_plugin/dialogs/dialog_registration.py
+++ b/poiskmore_plugin/dialogs/dialog_registration.py
@@ -1,5 +1,20 @@
 import sqlite3
-from PyQt5.QtWidgets import QDialog, QLineEdit, QPushButton, QVBoxLayout, QMessageBox, QLabel, QTabWidget, QTextEdit, QComboBox, QDoubleSpinBox, QSpinBox, QDateTimeEdit, QCheckBox
+from PyQt5.QtWidgets import (
+    QDialog,
+    QLineEdit,
+    QPushButton,
+    QVBoxLayout,
+    QMessageBox,
+    QLabel,
+    QTabWidget,
+    QTextEdit,
+    QComboBox,
+    QDoubleSpinBox,
+    QSpinBox,
+    QDateTimeEdit,
+    QCheckBox,
+    QWidget,
+)
 from PyQt5.QtCore import QDateTime
 from math import cos, sin, radians
 


### PR DESCRIPTION
## Summary
- ensure RegistrationDialog imports QWidget from PyQt5

## Testing
- `pytest` *(fails: NameError/SyntaxError during collection)*

------
https://chatgpt.com/codex/tasks/task_e_689b2c3effd083309d94b99767ce62d5