### PR TITLE
Fix manual area drawing and search dialog parameters

### DIFF
--- a/poiskmore_plugin/alg/alg_manual_area.py
+++ b/poiskmore_plugin/alg/alg_manual_area.py
@@ -1,25 +1,57 @@
-from qgis.gui import QgsMapToolEmitPoint
-from qgis.core import QgsGeometry, QgsPointXY
+"""Tools for manual construction of a search area."""
+
+from qgis.gui import QgsMapTool, QgsRubberBand
+from qgis.core import QgsGeometry, QgsPointXY, QgsWkbTypes
+from qgis.PyQt.QtGui import QColor
+
+from .alg_zone import add_search_layer
 
 
-class ManualAreaTool(QgsMapToolEmitPoint):
-    """Map tool for drawing a manual search area."""
+class ManualAreaTool(QgsMapTool):
+    """Map tool that allows the user to digitise a polygon manually.
+
+    The previous implementation relied solely on ``QgsMapToolEmitPoint`` and
+    called the callback as soon as three points were collected.  This meant the
+    user never saw the shape being drawn and the resulting geometry wasn't
+    explicitly closed which led to confusing behaviour.  The updated tool uses a
+    ``QgsRubberBand`` to provide visual feedback and only finalises the polygon
+    when the user double‑clicks.
+    """
 
     def __init__(self, canvas, callback):
         super().__init__(canvas)
-        self.points = []
+        self.canvas = canvas
         self.callback = callback
+        self.points = []
+        self.rubber_band = QgsRubberBand(canvas, QgsWkbTypes.PolygonGeometry)
+        self.rubber_band.setColor(QColor(255, 0, 0, 150))
+        self.rubber_band.setFillColor(QColor(255, 0, 0, 40))
+        self.rubber_band.setWidth(2)
 
-    def canvasPressEvent(self, e):
-        point = self.toMapCoordinates(e.pos())
+    def canvasPressEvent(self, event):
+        point = self.toMapCoordinates(event.pos())
         self.points.append(point)
+        self.rubber_band.addPoint(point, True)
+        self.rubber_band.show()
+
+    def canvasDoubleClickEvent(self, event):
+        """Finish polygon on double click."""
         if len(self.points) >= 3:
-            polygon = QgsGeometry.fromPolygonXY([self.points])
+            # close ring by repeating the first point
+            ring = self.points + [self.points[0]]
+            polygon = QgsGeometry.fromPolygonXY([ring])
             self.callback(polygon)
-            self.deactivate()
+        self.deactivate()
+
+    def deactivate(self):
+        """Reset temporary graphics and state."""
+        self.rubber_band.reset(QgsWkbTypes.PolygonGeometry)
+        self.points = []
+        super().deactivate()
 
 
 def manual_area(iface):
     """Activate manual area drawing tool."""
-    tool = ManualAreaTool(iface.mapCanvas(), lambda geom: add_search_layer(geom))
+
+    tool = ManualAreaTool(iface.mapCanvas(), add_search_layer)
     iface.mapCanvas().setMapTool(tool)

--- a/poiskmore_plugin/dialogs/dialog_search_params.py
+++ b/poiskmore_plugin/dialogs/dialog_search_params.py
@@ -1,16 +1,36 @@
-from PyQt5.QtWidgets import QDialog, QDoubleSpinBox, QPushButton, QVBoxLayout, QLabel
+"""Dialog for entering parameters for search area creation.
+
+The real plugin contains a rather complex dialog defined in the ``forms``
+directory, however for the purposes of the tests in this kata a very small
+subset is required.  The previous implementation only provided an ``OK``
+button and a spin box, but it lacked a method to return the user provided
+values which resulted in ``AttributeError`` being raised when the dialog was
+used by :func:`mainPlugin.search_two_points`.
+
+This module now exposes a tiny dialog with a ``get_params`` method returning
+the parameters needed by the ``create_search_area`` helper.
+"""
+
+from PyQt5.QtWidgets import (
+    QDialog,
+    QDoubleSpinBox,
+    QPushButton,
+    QVBoxLayout,
+    QLabel,
+)
 
 
 class SearchParamsDialog(QDialog):
-    """Dialog for specifying search parameters."""
+    """Minimal dialog for specifying search parameters."""
 
     def __init__(self, parent=None):
         super().__init__(parent)
         layout = QVBoxLayout(self)
         layout.addWidget(QLabel("Параметры поиска:"))
 
-        self.radius = QDoubleSpinBox(minimum=0.1)
-        layout.addWidget(self.radius)
+        # Width of the search area corridor (in degrees).
+        self.width = QDoubleSpinBox(minimum=0.1, value=0.2)
+        layout.addWidget(self.width)
 
         btn = QPushButton("OK")
         btn.clicked.connect(self.ok)
@@ -18,3 +38,17 @@ class SearchParamsDialog(QDialog):
 
     def ok(self):
         self.accept()
+
+    def get_params(self):
+        """Return parameters selected in the dialog.
+
+        Returns
+        -------
+        dict
+            Dictionary with keys understood by ``create_search_area``.
+        """
+
+        # ``create_search_area`` expects a ``width`` value when operating in
+        # ``two_points`` mode.  The dialog only exposes a single spin box so we
+        # simply forward its value.
+        return {"width": float(self.width.value())}


### PR DESCRIPTION
## Summary
- implement get_params for SearchParamsDialog so search from two points works
- improve manual area tool to draw polygon with rubber band and close on completion

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'qgis'; SyntaxError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_689b78a336b48330a2522b20b5d84342