### PR TITLE
Fix registration dialog imports

### DIFF
--- a/poiskmore_plugin/dialogs/dialog_registration.py
+++ b/poiskmore_plugin/dialogs/dialog_registration.py
@@ -1,5 +1,22 @@
-pythonimport sqlite3
-from PyQt5.QtWidgets import QDialog, QLineEdit, QPushButton, QVBoxLayout, QMessageBox, QLabel, QTabWidget, QTextEdit, QComboBox, QDoubleSpinBox, QSpinBox, QDateTimeEdit, QHBoxLayout, QGroupBox, QFormLayout
+import sqlite3
+from PyQt5.QtWidgets import (
+    QDialog,
+    QLineEdit,
+    QPushButton,
+    QVBoxLayout,
+    QMessageBox,
+    QLabel,
+    QTabWidget,
+    QTextEdit,
+    QComboBox,
+    QDoubleSpinBox,
+    QSpinBox,
+    QDateTimeEdit,
+    QHBoxLayout,
+    QGroupBox,
+    QFormLayout,
+    QWidget,
+)
 from PyQt5.QtCore import QDateTime
 from math import cos, sin, radians
 from reportlab.lib.pagesizes import letter


### PR DESCRIPTION
## Summary
- fix typo in registration dialog `sqlite3` import
- structure PyQt5 widget imports and include `QWidget`

## Testing
- `pytest` *(fails: NameError: name 'python' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68a4c93419f88330b513fa2e0e2cf4de