### PR TITLE
Add authorization dialog to fix import error

### DIFF
--- a/poiskmore_plugin/dialogs/__init__.py
+++ b/poiskmore_plugin/dialogs/__init__.py
@@ -1,2 +1,7 @@
 # -*- coding: utf-8 -*-
+"""Dialogs package."""
+
 from .incident_registration_dialog import IncidentRegistrationDialog
+from .authorization_dialog import AuthorizationDialog
+
+__all__ = ["IncidentRegistrationDialog", "AuthorizationDialog"]

--- a/poiskmore_plugin/dialogs/authorization_dialog.py
+++ b/poiskmore_plugin/dialogs/authorization_dialog.py
@@ -1,0 +1,40 @@
+from qgis.PyQt.QtWidgets import (
+    QDialog,
+    QDialogButtonBox,
+    QFormLayout,
+    QLineEdit,
+    QComboBox,
+)
+
+
+class AuthorizationDialog(QDialog):
+    """Простое диалоговое окно авторизации."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Авторизация")
+
+        self._login_edit = QLineEdit(self)
+        self._profile_combo = QComboBox(self)
+        self._profile_combo.addItems(["Оператор", "Администратор"])
+
+        layout = QFormLayout(self)
+        layout.addRow("Логин:", self._login_edit)
+        layout.addRow("Профиль:", self._profile_combo)
+
+        buttons = QDialogButtonBox(
+            QDialogButtonBox.Ok | QDialogButtonBox.Cancel,
+            parent=self,
+        )
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+        layout.addRow(buttons)
+
+    def get_user_data(self):
+        """Возвращает введенные данные пользователя или None."""
+        login = self._login_edit.text().strip()
+        profile = self._profile_combo.currentText().strip()
+        if login and profile:
+            return {"login": login, "profile": profile}
+        return None
+


### PR DESCRIPTION
## Summary
- add minimal AuthorizationDialog for user login/profile
- export AuthorizationDialog from dialogs package

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'qgis')*

------
https://chatgpt.com/codex/tasks/task_e_68ac1bf6ec7c83309e1d5cac2864ea0b