### PR TITLE
Fix missing emergency types handler

### DIFF
--- a/poiskmore_plugin/mainPlugin.py
+++ b/poiskmore_plugin/mainPlugin.py
@@ -207,9 +207,14 @@ class PoiskMorePlugin:
         """
         # Здесь можно обрабатывать дополнительные действия
         pass
-    
+
     # === СУЩЕСТВУЮЩИЕ ОБРАБОТЧИКИ (СОХРАНЯЕМ СОВМЕСТИМОСТЬ) ===
-    
+
+    def _on_emergency_types(self):
+        """Открыть диалог настройки типов аварийных ситуаций"""
+        dialog = EmergencyTypesDialog(self.iface.mainWindow())
+        dialog.exec_()
+
     def new_emergency_case(self):
         """Создать новый аварийный случай"""
         try:


### PR DESCRIPTION
## Summary
- add `_on_emergency_types` handler to open EmergencyTypesDialog

## Testing
- `python poiskmore_plugin/test_plugin_load.py` *(fails: No module named 'qgis')*
- `pytest` *(fails: No module named 'qgis')*

------
https://chatgpt.com/codex/tasks/task_e_68acc1c771ac8330a03deff81c35d7ed