### PR TITLE
Add placeholder help dialogs for calculators, IAMSAR and about

### DIFF
--- a/poiskmore_plugin/dialogs/__init__.py
+++ b/poiskmore_plugin/dialogs/__init__.py
@@ -3,5 +3,14 @@
 
 from .incident_registration_dialog import IncidentRegistrationDialog
 from .authorization_dialog import AuthorizationDialog
+from .about_dialog import AboutDialog
+from .calculators_dialog import CalculatorsDialog
+from .iamsar_reference_dialog import IAMSARReferenceDialog
 
-__all__ = ["IncidentRegistrationDialog", "AuthorizationDialog"]
+__all__ = [
+    "IncidentRegistrationDialog",
+    "AuthorizationDialog",
+    "AboutDialog",
+    "CalculatorsDialog",
+    "IAMSARReferenceDialog",
+]

--- a/poiskmore_plugin/dialogs/about_dialog.py
+++ b/poiskmore_plugin/dialogs/about_dialog.py
@@ -1,0 +1,15 @@
+from PyQt5.QtWidgets import QDialog, QVBoxLayout, QLabel, QPushButton
+
+class AboutDialog(QDialog):
+    """Simple about dialog for the plugin."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("О программе")
+
+        layout = QVBoxLayout(self)
+        layout.addWidget(QLabel("Плагин \"Поиск-Море\""))
+
+        close_btn = QPushButton("Закрыть")
+        close_btn.clicked.connect(self.accept)
+        layout.addWidget(close_btn)

--- a/poiskmore_plugin/dialogs/calculators_dialog.py
+++ b/poiskmore_plugin/dialogs/calculators_dialog.py
@@ -1,0 +1,15 @@
+from PyQt5.QtWidgets import QDialog, QVBoxLayout, QLabel, QPushButton
+
+class CalculatorsDialog(QDialog):
+    """Placeholder dialog for various calculators."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Калькуляторы")
+
+        layout = QVBoxLayout(self)
+        layout.addWidget(QLabel("Калькуляторы находятся в разработке."))
+
+        close_btn = QPushButton("Закрыть")
+        close_btn.clicked.connect(self.accept)
+        layout.addWidget(close_btn)

--- a/poiskmore_plugin/dialogs/dialog_about.py
+++ b/poiskmore_plugin/dialogs/dialog_about.py
@@ -1,9 +1,0 @@
-from PyQt5.QtWidgets import QDialog, QLabel, QPushButton, QVBoxLayout
-class DialogAbout(QDialog):
-def __init__(self, parent=None):
-super().__init__(parent)
-layout = QVBoxLayout(self)
-layout.addWidget(QLabel("О программе: Поиск-Море v1.0"))
-btn = QPushButton("Закрыть")
-btn.clicked.connect(self.close)
-layout.addWidget(btn)

--- a/poiskmore_plugin/dialogs/iamsar_reference_dialog.py
+++ b/poiskmore_plugin/dialogs/iamsar_reference_dialog.py
@@ -1,0 +1,15 @@
+from PyQt5.QtWidgets import QDialog, QVBoxLayout, QLabel, QPushButton
+
+class IAMSARReferenceDialog(QDialog):
+    """Dialog displaying a placeholder for the IAMSAR methodology."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Методика IAMSAR")
+
+        layout = QVBoxLayout(self)
+        layout.addWidget(QLabel("Справочный материал IAMSAR пока недоступен."))
+
+        close_btn = QPushButton("Закрыть")
+        close_btn.clicked.connect(self.accept)
+        layout.addWidget(close_btn)


### PR DESCRIPTION
## Summary
- add simple About, Calculators and IAMSAR dialogs so help menu works
- register new dialogs in dialogs package and remove obsolete file

## Testing
- `python -m py_compile poiskmore_plugin/dialogs/about_dialog.py poiskmore_plugin/dialogs/calculators_dialog.py poiskmore_plugin/dialogs/iamsar_reference_dialog.py poiskmore_plugin/dialogs/__init__.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'qgis')*

------
https://chatgpt.com/codex/tasks/task_e_68b0dc36c25083309010e587c254dab3