### PR TITLE
Fix plugin initialization indentation

### DIFF
--- a/poiskmore_plugin/mainPlugin.py
+++ b/poiskmore_plugin/mainPlugin.py
@@ -6,7 +6,6 @@
 
 import os
 from .dialogs.emergency_types_dialog import EmergencyTypesDialog
-from PyQt5.QtWidgets import QAction
 from qgis.PyQt.QtWidgets import QAction, QMenu, QDialog, QMessageBox
 from .dialogs.incident_registration_dialog import IncidentRegistrationDialog
 from qgis.PyQt.QtCore import QSettings, QTranslator, QCoreApplication
@@ -54,11 +53,13 @@ class PoiskMorePlugin:
         
         # Менеджер меню - будет создан в initGui
         self.menu_manager = None
-        
+
         # Данные операций (сохраняем совместимость)
         self.current_operation = None
         self.operations = []
         self._map_tool = None
+        # Зарезервированная ссылка на боковую панель плагина
+        self._pm_sidebar = None
         
         # Инициализация переводчика для локализации
         locale = QSettings().value('locale/userLocale')[0:2]


### PR DESCRIPTION
## Summary
- remove duplicate PyQt import
- add explicit `_pm_sidebar` placeholder inside `PoiskMorePlugin.__init__`

## Testing
- `python -m py_compile poiskmore_plugin/mainPlugin.py`
- `pytest poiskmore_plugin/test_plugin_load.py -q` *(fails: ModuleNotFoundError: No module named 'qgis')*


------
https://chatgpt.com/codex/tasks/task_e_68b235be0cfc833096a5d81927ccd46d