### PR TITLE
Fix indentation error in main plugin

### DIFF
--- a/poiskmore_plugin/mainPlugin.py
+++ b/poiskmore_plugin/mainPlugin.py
@@ -43,7 +43,6 @@ class PoiskMorePlugin:
     """
     
     def __init__(self, iface):
-    self._pm_sidebar = None
         """
         Конструктор плагина
         


### PR DESCRIPTION
## Summary
- remove stray unindented line in `PoiskMorePlugin.__init__`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'qgis'; syntax errors in test files)*

------
https://chatgpt.com/codex/tasks/task_e_68b23a46975883308338771d0eea7d7f