### PR TITLE
Fix raising overlay for QGIS 3.40

### DIFF
--- a/poiskmore_plugin/ui/pm_sidebar_dock.py
+++ b/poiskmore_plugin/ui/pm_sidebar_dock.py
@@ -184,7 +184,12 @@ class BasemapManager:
         if not grp: return
         for node in grp.findLayers():
             if node.layer().name() == LAYER_SEAMARKS:
-                grp.moveLayer(node, 0)  # вверх группы
+                layer = node.layer()
+                # QgsLayerTreeGroup.moveLayer() был удалён в QGIS 3.40.
+                # Удаляем слой из группы и вставляем его в начало, чтобы
+                # сохранить прежнее поведение "поднять overlay".
+                grp.removeLayer(layer)
+                grp.insertLayer(0, layer)
                 break
 
 # ---------- Основной Dock ----------


### PR DESCRIPTION
## Summary
- Replace removed `moveLayer` API to keep seamarks overlay on top of basemap in QGIS 3.40

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'qgis')*

------
https://chatgpt.com/codex/tasks/task_e_68b23cb9046883309950e0aa078701a1