### PR TITLE
fix: correct service menu docstring indentation

### DIFF
--- a/poiskmore_plugin/menu_structure.py
+++ b/poiskmore_plugin/menu_structure.py
@@ -342,7 +342,9 @@ class MenuManager(QObject):
         self.menu_action_triggered.emit('show_operation_tab')
 
     def _create_service_menu(self):
-        """Создать меню 'Сервис' - настройки и авторизация."""
+        """
+        Создать меню 'Сервис' - настройки и авторизация.
+        """
         service_menu = QMenu("Сервис", self.main_menu)
         service_menu.setObjectName("service_menu")
         self.menus['service'] = service_menu


### PR DESCRIPTION
## Summary
- ensure `_create_service_menu` docstring is properly indented

## Testing
- `python -m py_compile poiskmore_plugin/menu_structure.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'qgis')*

------
https://chatgpt.com/codex/tasks/task_e_68c80340850c8330a26e46c727373ccc