### PR TITLE
fix: inline service menu docstring

### DIFF
--- a/poiskmore_plugin/menu_structure.py
+++ b/poiskmore_plugin/menu_structure.py
@@ -342,9 +342,7 @@ class MenuManager(QObject):
         self.menu_action_triggered.emit('show_operation_tab')
 
     def _create_service_menu(self):
-        """
-        Создать меню 'Сервис' - настройки и авторизация.
-        """
+        """Создать меню 'Сервис' - настройки и авторизация."""
         service_menu = QMenu("Сервис", self.main_menu)
         service_menu.setObjectName("service_menu")
         self.menus['service'] = service_menu


### PR DESCRIPTION
## Summary
- inline service menu docstring to avoid indentation error during plugin load

## Testing
- `python3 -m py_compile poiskmore_plugin/menu_structure.py`
- `python3 -m tabnanny -v poiskmore_plugin/menu_structure.py`
- `pytest` *(fails: SyntaxError: invalid syntax, NameError: name 'python' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68c811cb04b883309915b92e5c122ef6