### PR TITLE
Fix indentation in service menu creation

### DIFF
--- a/poiskmore_plugin/menu_structure.py
+++ b/poiskmore_plugin/menu_structure.py
@@ -342,7 +342,9 @@ class MenuManager(QObject):
         self.menu_action_triggered.emit('show_operation_tab')
 
     def _create_service_menu(self):
-        """Создать меню 'Сервис' - настройки и авторизация."""
+        """
+        Создать меню "Сервис" - настройки и авторизация.
+        """
         service_menu = QMenu("Сервис", self.main_menu)
         service_menu.setObjectName("service_menu")
         self.menus['service'] = service_menu


### PR DESCRIPTION
## Summary
- fix service menu creation function docstring indentation

## Testing
- `python -m py_compile poiskmore_plugin/menu_structure.py`
- `python -m py_compile $(find poiskmore_plugin -name '*.py')` *(fails: SyntaxError in `poiskmore_plugin/alg/segment_intersection_detector.py`)*

------
https://chatgpt.com/codex/tasks/task_e_68c828cf4b6483309c1d3bfa0c362e43