### PR TITLE
fix: correct indentation for service menu

### DIFF
--- a/poiskmore_plugin/menu_structure.py
+++ b/poiskmore_plugin/menu_structure.py
@@ -342,9 +342,7 @@ class MenuManager(QObject):
         self.menu_action_triggered.emit('show_operation_tab')
 
     def _create_service_menu(self):
-        """
-        Создать меню "Сервис" - настройки и авторизация.
-        """
+        """Создать меню "Сервис" - настройки и авторизация."""
         service_menu = QMenu("Сервис", self.main_menu)
         service_menu.setObjectName("service_menu")
         self.menus['service'] = service_menu
@@ -387,9 +385,7 @@ class MenuManager(QObject):
         self.main_menu.addMenu(service_menu)
     
     def _create_datum_menu(self):
-        """
-        Создать меню "Исходный пункт" - расчет исходных точек поиска
-        """
+        """Создать меню "Исходный пункт" - расчет исходных точек поиска"""
         datum_menu = QMenu("Исходный пункт", self.main_menu)
         datum_menu.setObjectName("datum_menu")
         self.menus['datum'] = datum_menu
@@ -422,9 +418,7 @@ class MenuManager(QObject):
         self.main_menu.addMenu(datum_menu)
     
     def _create_area_menu(self):
-        """
-        Создать меню "Район" - управление районами поиска
-        """
+        """Создать меню "Район" - управление районами поиска"""
         area_menu = QMenu("Район", self.main_menu)
         area_menu.setObjectName("area_menu")
         self.menus['area'] = area_menu


### PR DESCRIPTION
## Summary
- fix indentation of menu creation methods to prevent plugin loading error

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'qgis'; SyntaxError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c8382dab608330b814b0779b12347d