### PR TITLE
Fix indentation error triggered by docstrings in menu manager

### DIFF
--- a/poiskmore_plugin/menu_structure.py
+++ b/poiskmore_plugin/menu_structure.py
@@ -1,9 +1,8 @@
 # -*- coding: utf-8 -*-
-"""
-Модуль управления структурой меню плагина ПОИСК-МОРЕ
-Соответствует документации и методике проведения поисково-спасательных операций
-Версия 2.0.0
-"""
+"""Модуль управления структурой меню плагина ПОИСК-МОРЕ.
+
+Соответствует документации и методике проведения поисково-спасательных операций.
+Версия 2.0.0."""
 
 from qgis.PyQt.QtCore import QObject, pyqtSignal, QSettings
 from qgis.PyQt.QtGui import QIcon, QAction
@@ -12,10 +11,9 @@ from typing import Dict, List, Optional, Callable
 import os
 
 class MenuManager(QObject):
-    """
-    Менеджер структуры меню плагина
-    Управляет созданием, видимостью и состоянием всех элементов меню
-    """
+    """Менеджер структуры меню плагина.
+
+    Управляет созданием, видимостью и состоянием всех элементов меню."""
     
     # Сигналы для взаимодействия с другими компонентами
     operation_started = pyqtSignal(dict)  # Начата новая операция
@@ -23,13 +21,11 @@ class MenuManager(QObject):
     menu_action_triggered = pyqtSignal(str)  # Вызвано действие меню
     
     def __init__(self, iface, plugin_dir):
-        """
-        Инициализация менеджера меню
-        
+        """Инициализация менеджера меню.
+
         Args:
-            iface: Интерфейс QGIS
-            plugin_dir: Путь к директории плагина
-        """
+            iface: Интерфейс QGIS.
+            plugin_dir: Путь к директории плагина."""
         super().__init__()
         self.iface = iface
         self.plugin_dir = plugin_dir
@@ -49,9 +45,7 @@ class MenuManager(QObject):
         self.main_menu = None
         
     def create_menu_structure(self):
-        """
-        Создать полную структуру меню согласно документации
-        """
+        """Создать полную структуру меню согласно документации."""
         # Создаем главное меню
         self.main_menu = QMenu("ПОИСК-МОРЕ", self.iface.mainWindow().menuBar())
         self.iface.mainWindow().menuBar().addMenu(self.main_menu)
@@ -71,9 +65,7 @@ class MenuManager(QObject):
         self._update_menu_state()
     
     def _create_search_menu(self):
-        """
-        Создать меню "Поиск" - главное меню для работы с операциями
-        """
+        """Создать меню "Поиск" — главное меню для работы с операциями."""
         search_menu = QMenu("Поиск", self.main_menu)
         search_menu.setObjectName("search_menu")
         self.menus['search'] = search_menu
@@ -291,24 +283,20 @@ class MenuManager(QObject):
     # === ВСПОМОГАТЕЛЬНЫЕ МЕТОДЫ ===
     
     def _get_icon(self, icon_name):
-        """
-        Получить иконку из директории icons
-        
+        """Получить иконку из директории icons.
+
         Args:
-            icon_name: Имя файла иконки
-            
+            icon_name: Имя файла иконки.
+
         Returns:
-            QIcon объект или пустая иконка если файл не найден
-        """
+            QIcon объект или пустая иконка, если файл не найден."""
         icon_path = os.path.join(self.icons_dir, icon_name)
         if os.path.exists(icon_path):
             return QIcon(icon_path)
         return QIcon()
     
     def _update_menu_state(self):
-        """
-        Обновить состояние элементов меню в зависимости от состояния операции
-        """
+        """Обновить состояние элементов меню в зависимости от состояния операции."""
         # Элементы, требующие активной операции
         operation_required = [
             'edit_info', 'close_search', 'finish_search',
@@ -385,9 +373,7 @@ class MenuManager(QObject):
         self.main_menu.addMenu(service_menu)
     
     def _create_datum_menu(self):
-        """
-        Создать меню "Исходный пункт" - расчет исходных точек поиска
-        """
+        """Создать меню "Исходный пункт" для расчета исходных точек поиска."""
         datum_menu = QMenu("Исходный пункт", self.main_menu)
         datum_menu.setObjectName("datum_menu")
         self.menus['datum'] = datum_menu
@@ -420,9 +406,7 @@ class MenuManager(QObject):
         self.main_menu.addMenu(datum_menu)
     
     def _create_area_menu(self):
-        """
-        Создать меню "Район" - управление районами поиска
-        """
+        """Создать меню "Район" для управления районами поиска."""
         area_menu = QMenu("Район", self.main_menu)
         area_menu.setObjectName("area_menu")
         self.menus['area'] = area_menu
@@ -625,12 +609,10 @@ class MenuManager(QObject):
     # === ОБРАБОТЧИКИ МЕНЮ "РАЙОН" ===
     
     def _on_create_area(self, area_type):
-        """
-        Обработчик создания района поиска
-        
+        """Обработчик создания района поиска.
+
         Args:
-            area_type: Тип района поиска
-        """
+            area_type: Тип района поиска."""
         if not self.operation_active:
             QMessageBox.warning(
                 self.iface.mainWindow(),
@@ -698,9 +680,7 @@ class MenuManager(QObject):
             )
 
     def _create_documents_menu(self):
-        """
-        Создать меню "Документы" - формы и отчеты
-        """
+        """Создать меню "Документы" для работы с формами и отчетами."""
         docs_menu = QMenu("Документы", self.main_menu)
         docs_menu.setObjectName("documents_menu")
         self.menus['documents'] = docs_menu
@@ -744,9 +724,7 @@ class MenuManager(QObject):
         self.main_menu.addMenu(docs_menu)
     
     def _create_help_menu(self):
-        """
-        Создать меню "Помощь" - справка и документация
-        """
+        """Создать меню "Помощь" со справочной документацией."""
         help_menu = QMenu("Помощь", self.main_menu)
         help_menu.setObjectName("help_menu")
         self.menus['help'] = help_menu
@@ -801,9 +779,7 @@ class MenuManager(QObject):
         self.main_menu.addMenu(help_menu)
     
     def _create_toolbar(self):
-        """
-        Создать панель инструментов с быстрым доступом к основным функциям
-        """
+        """Создать панель инструментов с быстрым доступом к основным функциям."""
         toolbar = self.iface.addToolBar("ПОИСК-МОРЕ")
         toolbar.setObjectName("poisk_more_toolbar")
         self.toolbars['main'] = toolbar
@@ -933,12 +909,10 @@ class MenuManager(QObject):
     # === МЕТОДЫ РАБОТЫ С ОПЕРАЦИЯМИ ===
     
     def _save_operation_state(self, status='active'):
-        """
-        Сохранить состояние текущей операции
-        
+        """Сохранить состояние текущей операции.
+
         Args:
-            status: Статус операции (active, suspended, completed)
-        """
+            status: Статус операции (active, suspended, completed)."""
         if not self.operation_data:
             return
         
@@ -951,12 +925,10 @@ class MenuManager(QObject):
         db.save_operation(self.operation_data)
     
     def _load_operation(self, operation_id):
-        """
-        Загрузить операцию по ID
-        
+        """Загрузить операцию по идентификатору.
+
         Args:
-            operation_id: Идентификатор операции
-        """
+            operation_id: Идентификатор операции."""
         from .utils.db_manager import DatabaseManager
         
         db = DatabaseManager()
@@ -969,12 +941,10 @@ class MenuManager(QObject):
             self.operation_started.emit(operation_data)
     
     def _archive_operation(self, finish_data):
-        """
-        Архивировать завершенную операцию
-        
+        """Архивировать завершенную операцию.
+
         Args:
-            finish_data: Данные о завершении операции
-        """
+            finish_data: Данные о завершении операции."""
         from .utils.db_manager import DatabaseManager
         
         db = DatabaseManager()
@@ -986,12 +956,10 @@ class MenuManager(QObject):
         db.archive_operation(self.operation_data)
     
     def _load_archived_case(self, case_id):
-        """
-        Загрузить архивное дело для повторного поиска
-        
+        """Загрузить архивное дело для повторного поиска.
+
         Args:
-            case_id: Идентификатор дела
-        """
+            case_id: Идентификатор дела."""
         from .utils.db_manager import DatabaseManager
         
         db = DatabaseManager()
@@ -1085,12 +1053,10 @@ class MenuManager(QObject):
         self.menu_action_triggered.emit('update_statistics')
     
     def _generate_form(self, form_type):
-        """
-        Генерировать стандартную форму
-        
+        """Генерировать стандартную форму.
+
         Args:
-            form_type: Тип формы для генерации
-        """
+            form_type: Тип формы для генерации."""
         from .reports.standard_forms import StandardFormsGenerator
         
         generator = StandardFormsGenerator()
@@ -1108,12 +1074,10 @@ class MenuManager(QObject):
             webbrowser.open(file_path)
     
     def _generate_search_plan_document(self, plan_data):
-        """
-        Генерировать документ плана поиска
-        
+        """Генерировать документ плана поиска.
+
         Args:
-            plan_data: Данные плана поиска
-        """
+            plan_data: Данные плана поиска."""
         from .reports.search_plan_generator import SearchPlanGenerator
         
         generator = SearchPlanGenerator()
@@ -1131,9 +1095,7 @@ class MenuManager(QObject):
             webbrowser.open(file_path)
     
     def cleanup(self):
-        """
-        Очистка ресурсов при выгрузке плагина
-        """
+        """Очистка ресурсов при выгрузке плагина."""
         # Сохраняем текущую операцию если есть
         if self.operation_active:
             self._save_operation_state()


### PR DESCRIPTION
## Summary
- normalize module, class and method docstrings in `menu_structure.py` so that no bare triple-quote lines remain
- adjust wording in multi-line docstrings to keep descriptions while preventing stripped indentation from causing runtime errors

## Testing
- python -m py_compile poiskmore_plugin/menu_structure.py
- python -m compileall poiskmore_plugin

------
https://chatgpt.com/codex/tasks/task_e_68c942492d308330973ae6082b260a5e