### PR TITLE
Gracefully handle missing zoom-to-center handler

### DIFF
--- a/poiskmore_plugin/ui/pm_sidebar_dock.py
+++ b/poiskmore_plugin/ui/pm_sidebar_dock.py
@@ -23,7 +23,7 @@ from qgis.PyQt.QtWidgets import (
 )
 from qgis.core import (
     QgsProject, QgsRasterLayer, QgsVectorLayer, QgsFeatureRequest,
-    QgsRectangle, QgsApplication
+    QgsRectangle, QgsApplication, Qgis
 )
 
 # ---------- Константы ----------
@@ -297,7 +297,24 @@ class PoiskMoreSidebarDock(QDockWidget):
         self.btnRepair.clicked.connect(self._repair_links)
         self.btnStyles.clicked.connect(self._apply_styles)
 
-        self.btnZoom.clicked.connect(self._zoom_to_center)
+        zoom_handler = getattr(self, "_zoom_to_center", None)
+        if zoom_handler:
+            self.btnZoom.clicked.connect(zoom_handler)
+        else:
+            def _missing_zoom_handler():
+                QMessageBox.warning(
+                    self,
+                    "Поиск‑Море",
+                    "Эта сборка плагина не поддерживает приближение к центрам."
+                )
+
+            self._missing_zoom_handler = _missing_zoom_handler
+            self.btnZoom.clicked.connect(self._missing_zoom_handler)
+            QgsApplication.messageLog().logMessage(
+                "Zoom-to-center handler is missing; falling back to stub.",
+                "Poisk-More",
+                Qgis.Warning
+            )
         self.btnHealth.clicked.connect(self._check_services)
 
     # --- Инициализация групп ---


### PR DESCRIPTION
## Summary
- guard the sidebar zoom button wiring so the plugin still loads when the handler is absent
- log a warning and show a message-box stub instead of raising an AttributeError during sidebar init

## Testing
- python -m compileall poiskmore_plugin/ui/pm_sidebar_dock.py

------
https://chatgpt.com/codex/tasks/task_e_68ca000489908330ac235dd3daa58108